### PR TITLE
Account for scenario where embeddings is defined but is an empty array

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function getScenarioSummary(scenario) {
       duration += step.result.duration;
     }
 
-    if (step.embeddings) {
+    if (step.embeddings && step.embeddings.length > 0) {
       embeddings.push(step.embeddings[0].data);
     }
 


### PR DESCRIPTION
Codecept reporter [codeceptjs-cucumber-json-reporter](https://www.npmjs.com/package/codeceptjs-cucumber-json-reporter) generates step embeddings as an empty array.  This change will account for that possibility so conversion attempts don't fail.