### PR TITLE
Adding option featureNameAsClassName

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ const cucumberJunitConvert = require('cucumber-junit-convert');
 
 const options = {
     inputJsonFile: '<filename>.json',
-    outputXmlFile: '<filename>.xml'
+    outputXmlFile: '<filename>.xml',
+    featureNameAsClassName: true // default: false
 }
 
 cucumberJunitConvert.convert(options);
@@ -32,6 +33,9 @@ License
 
 Changelog
 ---------
+
+### 2.1.0
+- add option to use the Feature name as the JUnit className: `featureNameAsClassName`
 
 ### 2.0.0
 - add embeddings support 

--- a/index.js
+++ b/index.js
@@ -15,11 +15,13 @@ function convert(options) {
       const result = getScenarioSummary(scenario);
       durationInSec += result.duration;
       if (result.status === 'failed') {
+        const className = options.featureNameAsClassName ? feature.name : scenario.id;
+        
         if (result.embeddings.length) {
           suite
             .testCase()
             .name(scenario.name)
-            .className(scenario.id)
+            .className(className)
             .standardError(result.message)
             .errorAttachment(result.embeddings[0])
             .failure(result.message)
@@ -28,7 +30,7 @@ function convert(options) {
           suite
             .testCase()
             .name(scenario.name)
-            .className(scenario.id)
+            .className(className)
             .failure(result.message)
             .time(result.duration);
         }
@@ -36,14 +38,14 @@ function convert(options) {
         suite
           .testCase()
           .name(scenario.name)
-          .className(scenario.id)
+          .className(className)
           .skipped()
           .time(result.duration);
       } else {
         suite
           .testCase()
           .name(scenario.name)
-          .className(scenario.id)
+          .className(className)
           .time(result.duration);
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumber-junit-convert",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
So that we have the option to use the Gherkin Feature name as the JUnit ClassName instead of the Scenario id.

For example:

"Login" (Feature name) instead of "login;logging-in-with-a-valid-set-of-credentials" (Scenario Id)

P.S.: backwards-compatible because the old behavior is still the default behavior.