### PR TITLE
Adds Option to Fail Test on Undefined Steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ const cucumberJunitConvert = require('cucumber-junit-convert');
 const options = {
     inputJsonFile: '<filename>.json',
     outputXmlFile: '<filename>.xml',
-    featureNameAsClassName: true // default: false
+    featureNameAsClassName: true, // default: false
+    failOnUndefinedStep: false // default: false
 }
 
 cucumberJunitConvert.convert(options);

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function getScenarioSummary(scenario, options) {
       embeddings.push(step.embeddings[0].data);
     }
 
-    if (step.result.status == 'failed' || options.failOnUndefinedStep && step.result.status == 'undefined') {
+    if (step.result.status == 'failed' || !!options.failOnUndefinedStep && step.result.status == 'undefined') {
       status = 'failed';
       message = step.result.error_message;
     } else if (

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function convert(options) {
         return;
       }
 
-      const result = getScenarioSummary(scenario);
+      const result = getScenarioSummary(scenario, options);
       const className = options.featureNameAsClassName ? feature.name : scenario.id;
 
       durationInSec += result.duration;
@@ -56,7 +56,7 @@ function convert(options) {
   reportBuilder.writeTo(options.outputXmlFile);
 }
 
-function getScenarioSummary(scenario) {
+function getScenarioSummary(scenario, options) {
   let status = 'passed';
   let message = null;
   let duration = 0;
@@ -71,7 +71,7 @@ function getScenarioSummary(scenario) {
       embeddings.push(step.embeddings[0].data);
     }
 
-    if (step.result.status == 'failed') {
+    if (step.result.status == 'failed' || options.failOnUndefinedStep && step.result.status == 'undefined') {
       status = 'failed';
       message = step.result.error_message;
     } else if (

--- a/tests/index.js
+++ b/tests/index.js
@@ -3,7 +3,8 @@ const cucumberJunitConvert = require('../index');
 const options = {
     inputJsonFile: './tests/resources/default-cucumber-report.json',
     outputXmlFile: './tests/resources/test-report.xml',
-    featureNameAsClassName: false
+    featureNameAsClassName: false,
+    failOnUndefinedStep: false
 }
 
 cucumberJunitConvert.convert(options);


### PR DESCRIPTION
When run in strict mode, Cucumber will consider a scenario failed if a step is undefined. Adding this option will allow junit reports generated by this tool to reflect this behavior.